### PR TITLE
コンフィグファイルを読み込むクラスを追加

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,4 @@
+{
+    "use_exchange" : ["bitflyer", "coincheck"],
+    "use_cryptocurrency" : ["BTC"] 
+}

--- a/src/main.py
+++ b/src/main.py
@@ -4,12 +4,15 @@
 
 from src.common.common import CryptoType, TickerInfo, ExchangeType, WebAPIErrorCode
 from src.web_handler.exchange_handler import ExchangeHandler
+from src.util.config_reader import ConfigReader
+import pprint
 
 if __name__=='__main__':
     print("info: システムトレードを開始します。")
 
-    bitflyer_handler = ExchangeHandler(ExchangeType.BITFLYER)
-    error_code, ticker_info = bitflyer_handler.fetch_ticker_info(CryptoType.BTC)
-    assert error_code, WebAPIErrorCode.OK
+    error_code, use_crypto_types = ConfigReader.GetUseCryptoTypes("../config/config.json")
+    pprint.pprint(use_crypto_types)
+    error_code, use_exchange_types = ConfigReader.GetUseExchangeTypes("../config/config.json")
+    pprint.pprint(use_exchange_types)
 
     print("info: システムトレードを終了します。")

--- a/src/util/config_reader.py
+++ b/src/util/config_reader.py
@@ -1,0 +1,79 @@
+from src.common.common import ExchangeType
+from src.common.common import CryptoType
+from src.common.common import FileAccessErrorCode
+import json
+
+class ConfigReader:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def GetUseCryptoTypes(config_path):
+        '''
+        アービトラージで用いる仮想通貨種別一覧を取得する。
+
+        Params:
+        -------
+        config_path : string
+            コンフィグファイルパス。
+
+        Returns:
+        --------
+        error_code : FileAccessErrorCode
+            ファイルアクセスエラーコード。
+        crypto_type_list : array-like (CryptoType)
+            使用する仮想通貨種別一覧。
+        '''
+        try:
+            json_open = open(config_path, 'r')
+            json_load = json.load(json_open)
+            crypto_type_list = []
+            for crypto_name in json_load["use_cryptocurrency"]:
+                if crypto_name == "BTC":
+                    crypto_type_list.append(CryptoType.BTC)
+                elif crypto_name == "ETH":
+                    crypto_type_list.append(CryptoType.ETH)
+                else:
+                    print("warn: 無効な仮想通貨名が指定されています。")  # todo: エラーログに吐き出す。
+                    return FileAccessErrorCode.FAIL_READ, []
+            return FileAccessErrorCode.OK, crypto_type_list
+        except:
+            print("warn: コンフィグファイルのオープンに失敗しました。")  # todo: エラーログに吐き出す。
+            return FileAccessErrorCode.FAIL_OPEN, []
+
+
+    @staticmethod
+    def GetUseExchangeTypes(config_path):
+        '''
+        アービトラージで用いる取引所一覧を取得する。
+
+        Parameters:
+        -----------
+        config_path : string
+            コンフィグファイルパス。
+
+        Returns:
+        --------
+        error_code : FileAccessErrorCode
+            ファイルアクセスエラーコード。
+        exchange_type_list : array-like (ExchangeType)
+            使用する取引所一覧。
+        '''
+        try:
+            json_open = open(config_path, 'r')
+            json_load = json.load(json_open)
+            exchange_type_list = []
+            for exchange_name in json_load["use_exchange"]:
+                if exchange_name == "bitflyer":
+                    exchange_type_list.append(ExchangeType.BITFLYER)
+                elif exchange_name == "coincheck":
+                    exchange_type_list.append(ExchangeType.COINCHECK)
+                elif exchange_name == "gmo":
+                    exchange_type_list.append(ExchangeType.GMO)
+                else:
+                    print("warn: 無効な取引所名が指定されています。")  # todo: エラーログに吐き出す。
+                    return FileAccessErrorCode.FAIL_READ, []
+            return FileAccessErrorCode.OK, exchange_type_list
+        except:
+            print("warn: コンフィグファイルのオープンに失敗しました。")  # todo: エラーログに吐き出す。
+            return FileAccessErrorCode.FAIL_OPEN, []


### PR DESCRIPTION
# 概要
* コンフィグファイルからコンフィグ情報を読み込むクラス(ConfigReader)を追加
* コンフィグファイルを読み込むメソッド(GetUseCryptoTypes, GetUseExchangeTypes)には、呼び出し元ファイルからconfig/config.jsonへの相対パスを指定する必要がある
  * 例：src/main.py から呼び出す場合は、../config/config.json を指定する