### PR TITLE
ExchangeHandlerの単体テストを追加

### DIFF
--- a/src/common/common.py
+++ b/src/common/common.py
@@ -47,6 +47,7 @@ class WebAPIErrorCode(Enum):
     OK = 0,              # 呼び出し成功
     FAIL_CONNECTION = 1  # 通信失敗
     FAIL_ORDER = 2       # 注文失敗
+    SYS_ERROR = 3        # システムエラー
 
 
 class FileAccessErrorCode(Enum):

--- a/src/web_handler/coincheck_handler.py
+++ b/src/web_handler/coincheck_handler.py
@@ -23,11 +23,27 @@ class CoincheckHandler:
         self.api_endpoint = "https://coincheck.com"
 
     def fetch_ticker_info(self, crypto_type):
+        '''
+        板情報オブジェクトを取得する。
+        想定していない仮想通貨が指定された場合はプログラムを停止する。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨の種類。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+        　WebAPIエラーコード。
+        ticker_info : TickerInfo
+        　板情報オブジェクト。
+        '''
         path = "/api/order_books"
         url =  self.api_endpoint + path
         if crypto_type != CryptoType.BTC:
             print("error: Coincheckでは現在BTCのみ扱っています。プログラムを停止します。")  # todo:エラーログを吐き出す。
-            sys.exit()
+            return WebAPIErrorCode.SYS_ERROR, TickerInfo()
 
         try:
             json_data = requests.get(url, timeout=(self.connect_timeout, self.read_timeout)).json()

--- a/tool/test/exchange_handler_test.py
+++ b/tool/test/exchange_handler_test.py
@@ -1,0 +1,74 @@
+import unittest
+from src.common.common import *
+from src.web_handler.exchange_handler import *
+from src.web_handler.bitflyer_handler import *
+from src.web_handler.gmo_handler import *
+from src.web_handler.coincheck_handler import *
+
+
+class ExchangeHandlerTest(unittest.TestCase):
+    '''
+    ExchangeHandlerの単体テストクラス。
+    '''
+    def setUp(self):
+        self.exchange_types = [ExchangeType.GMO, ExchangeType.BITFLYER, ExchangeType.COINCHECK]
+        self.exchange_handler_class = {
+            ExchangeType.GMO: GmoHandler,
+            ExchangeType.BITFLYER: BitflyerHandler,
+            ExchangeType.COINCHECK: CoincheckHandler
+        }
+
+    def test_init(self):
+        '''
+        コンストラクタのテスト。
+        '''
+        for exchange_type in self.exchange_types:
+            handler = ExchangeHandler(exchange_type)
+            self.assertIsInstance(handler, ExchangeHandler)
+            self.assertIsInstance(handler.impl, self.exchange_handler_class[exchange_type])
+            self.assertEqual(handler.impl.api_key, "")
+            self.assertEqual(handler.impl.api_secret_key, "")
+            self.assertEqual(handler.impl.connect_timeout, 3.0)
+            self.assertEqual(handler.impl.read_timeout, 10.0)
+
+    def test_fetch_ticker_info(self):
+        for exchange_type in self.exchange_types:
+            handler = ExchangeHandler(exchange_type)
+            error_code, info = handler.fetch_ticker_info(CryptoType.BTC)
+            self.assertTrue(error_code in [WebAPIErrorCode.OK, WebAPIErrorCode.FAIL_CONNECTION])
+            self.assertIsInstance(info, TickerInfo)
+            if error_code == WebAPIErrorCode.OK:
+                # 無効値ではないことをチェック
+                self.assertTrue(info != TickerInfo())
+
+
+class GMOHandlerTest(unittest.TestCase):
+    '''
+    GMOHandlerの単体テストクラス。
+    '''
+    def setUp(self):
+        self.handler = GmoHandler()
+
+    def test_init(self):
+        self.assertEqual(self.handler.api_private_endpoint, "https://api.coin.z.com/private")
+        self.assertEqual(self.handler.api_public_endpoint, "https://api.coin.z.com/public")
+
+
+class CoincheckHandlerTest(unittest.TestCase):
+    '''
+    CoincheckHandlerの単体テストクラス。
+    '''
+    def setUp(self):
+        self.handler = CoincheckHandler()
+
+    def test_init(self):
+        self.assertEqual(self.handler.api_endpoint, "https://coincheck.com")
+
+    def test_fetch_ticker_info(self):
+        # 無効な仮想通貨種別でシステムエラーが発生する
+        error_code, info = self.handler.fetch_ticker_info(CryptoType.ETH)
+        self.assertIs(error_code, WebAPIErrorCode.SYS_ERROR)
+
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
### 概要
* ExchangeHandlerの単体テストを追加しました
* public API(価格取得APIなど)を中心にテストしています
  * private API(注文発注API, 残高照会API等)は、API keyが必要になるため単体テストは難しい
  * したがって、発注条件等のValidationを別メソッドに切ってそちらの単体テストを追加する方針