### PR TITLE
ExchangeHandlerから不要なAPIを削除

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,4 +11,6 @@ import time
 import codecs
 
 if __name__=='__main__':
-    pass
+    handler = ExchangeHandler(ExchangeType.HUOBI_JP)
+    code, info = handler.fetch_ticker_info(CryptoType.LTC)
+    info.print_myself()

--- a/src/web_handler/bitbank_handler.py
+++ b/src/web_handler/bitbank_handler.py
@@ -122,16 +122,5 @@ class BitbankHandler:
         '''
         return WebAPIErrorCode.OK
 
-    def cancel_expired_order(self):
-        '''
-        期限切れの注文をキャンセルする。
-
-        Returns:
-        --------
-        error_code : WebAPIErrorCode
-            WebAPIエラーコード。
-        '''
-        WebAPIErrorCode.OK
-
     def fetch_balance(self):
         return WebAPIErrorCode.OK, BalanceInfo()

--- a/src/web_handler/bitbank_handler.py
+++ b/src/web_handler/bitbank_handler.py
@@ -32,7 +32,6 @@ class BitbankHandler:
     def fetch_ticker_info(self, crypto_type):
         '''
         板情報オブジェクトを取得する。
-        想定していない仮想通貨が指定された場合はプログラムを停止する。
 
         Parameters:
         -----------
@@ -123,4 +122,14 @@ class BitbankHandler:
         return WebAPIErrorCode.OK
 
     def fetch_balance(self):
+        '''
+        取引所に預けている残高を取得する。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        balance_info : BalanceInfo
+            残高情報。
+        '''
         return WebAPIErrorCode.OK, BalanceInfo()

--- a/src/web_handler/bitflyer_handler.py
+++ b/src/web_handler/bitflyer_handler.py
@@ -59,9 +59,6 @@ class BitflyerHandler:
     def make_sell_market_order(self, crypto_type, volume):
         return WebAPIErrorCode.OK  # todo: 実装する
 
-    def cancel_expired_order(self):
-        return FileAccessErrorCode.OK  # todo: 実装する
-
     def fetch_balance(self):
         '''
         このへんが参考になりそう。

--- a/src/web_handler/bitflyer_handler.py
+++ b/src/web_handler/bitflyer_handler.py
@@ -21,6 +21,22 @@ class BitflyerHandler:
         self.api_endpoint = 'https://api.bitflyer.com'
 
     def fetch_ticker_info(self, crypto_type):
+        '''
+        板情報オブジェクトを取得する。
+        想定していない仮想通貨が指定された場合はプログラムを停止する。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨の種類。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+        　WebAPIエラーコード。
+        ticker_info : TickerInfo
+        　板情報オブジェクト。
+        '''
         path = '/v1/ticker'
         url = self.api_endpoint + path
         params = {}
@@ -46,6 +62,15 @@ class BitflyerHandler:
         return WebAPIErrorCode.OK, ticker_info
 
     def load_api_key(self):
+        '''
+        API Key, Secret keyをロードする。
+        注文を扱うメソッドを呼ぶ前には本メソッドを実行する必要がある。
+
+        Returns:
+        --------
+        error_code : FileAccessErrorCode
+            ファイルアクセスエラーコード。
+        '''
         error_code, api_key, api_secret_key = APIKeyReader.get_api_keys(ExchangeType.BITFLYER)
         if error_code != FileAccessErrorCode.OK:
             return error_code
@@ -54,15 +79,57 @@ class BitflyerHandler:
         return FileAccessErrorCode.OK
 
     def make_buy_market_order(self, crypto_type, volume):
+        '''
+        成行注文（買い）を出す。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨種別。
+        volume : float
+            数量。単位は仮想通貨による。
+        timeout : int
+            注文をキャンセルするまでの時間。[秒]
+            この時間内に約定しなかった場合は cancel_expired_order が呼ばれた時点でキャンセルされる。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        '''
         return WebAPIErrorCode.OK  # todo: 実装する
 
     def make_sell_market_order(self, crypto_type, volume):
+        '''
+        成行注文（売り）を出す。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨種別。
+        volume : float
+            数量。単位は仮想通貨による。
+        timeout : int
+            注文をキャンセルするまでの時間。[秒]
+            この時間内に約定しなかった場合は cancel_expired_order が呼ばれた時点でキャンセルされる。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        '''
         return WebAPIErrorCode.OK  # todo: 実装する
 
     def fetch_balance(self):
         '''
-        このへんが参考になりそう。
-        https://www.doraxdora.com/blog/2018/03/14/4181/
+        取引所に預けている残高を取得する。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        balance_info : BalanceInfo
+            残高情報。
         '''
         return WebAPIErrorCode.OK, BalanceInfo()  # todo: 実装する
 

--- a/src/web_handler/coincheck_handler.py
+++ b/src/web_handler/coincheck_handler.py
@@ -62,6 +62,15 @@ class CoincheckHandler:
         return WebAPIErrorCode.OK, ticker_info
 
     def load_api_key(self):
+        '''
+        API Key, Secret keyをロードする。
+        注文を扱うメソッドを呼ぶ前には本メソッドを実行する必要がある。
+
+        Returns:
+        --------
+        error_code : FileAccessErrorCode
+            ファイルアクセスエラーコード。
+        '''
         error_code, api_key, api_secret_key = APIKeyReader.get_api_keys(ExchangeType.COINCHECK)
         if error_code != FileAccessErrorCode.OK:
             return error_code
@@ -160,6 +169,16 @@ class CoincheckHandler:
         return WebAPIErrorCode.OK
 
     def fetch_balance(self):
+        '''
+        取引所に預けている残高を取得する。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        balance_info : BalanceInfo
+            残高情報。
+        '''
         path = "/api/accounts/balance"
         timestamp = '{0}000'.format(int(time.mktime(datetime.now().timetuple())))
         url = self.api_endpoint + path

--- a/src/web_handler/coincheck_handler.py
+++ b/src/web_handler/coincheck_handler.py
@@ -159,10 +159,6 @@ class CoincheckHandler:
               + str(volume) + " です。")
         return WebAPIErrorCode.OK
 
-
-    def cancel_expired_order(self):
-        return FileAccessErrorCode.OK  # todo: 実装する
-
     def fetch_balance(self):
         path = "/api/accounts/balance"
         timestamp = '{0}000'.format(int(time.mktime(datetime.now().timetuple())))

--- a/src/web_handler/exchange_handler.py
+++ b/src/web_handler/exchange_handler.py
@@ -115,17 +115,6 @@ class ExchangeHandler:
         '''
         return self.impl.make_sell_market_order(crypto_type, volume)
 
-    def cancel_expired_order(self):
-        '''
-        期限切れの注文をキャンセルする。
-
-        Returns:
-        --------
-        error_code : WebAPIErrorCode
-            WebAPIエラーコード。
-        '''
-        return self.impl.cancel_expired_order()
-
     def fetch_balance(self):
         '''
         取引所に預けている残高を取得する。

--- a/src/web_handler/gmo_handler.py
+++ b/src/web_handler/gmo_handler.py
@@ -140,9 +140,6 @@ class GmoHandler:
         print("info: GMOへの注文に成功しました。売買種別は " + side + ", 数量は " + str(volume) + " です。")
         return WebAPIErrorCode.OK
 
-    def cancel_expired_order(self):
-        return FileAccessErrorCode.OK  # todo: 実装する
-
     def fetch_balance(self):
         '''
         取引所に預けている残高を取得する。

--- a/src/web_handler/gmo_handler.py
+++ b/src/web_handler/gmo_handler.py
@@ -28,6 +28,21 @@ class GmoHandler:
         self.api_public_endpoint = "https://api.coin.z.com/public"
 
     def fetch_ticker_info(self, crypto_type):
+        '''
+        板情報オブジェクトを取得する。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨の種類。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+        　WebAPIエラーコード。
+        ticker_info : TickerInfo
+        　板情報オブジェクト。
+        '''
         path = "/v1/orderbooks"
         url = self.api_public_endpoint + path
         params = {}
@@ -55,6 +70,15 @@ class GmoHandler:
         return WebAPIErrorCode.OK, ticker_info
 
     def load_api_key(self):
+        '''
+        API Key, Secret keyをロードする。
+        注文を扱うメソッドを呼ぶ前には本メソッドを実行する必要がある。
+
+        Returns:
+        --------
+        error_code : FileAccessErrorCode
+            ファイルアクセスエラーコード。
+        '''
         error_code, api_key, api_secret_key = APIKeyReader.get_api_keys(ExchangeType.GMO)
         if error_code != FileAccessErrorCode.OK:
             return error_code

--- a/src/web_handler/huobi_jp_handler.py
+++ b/src/web_handler/huobi_jp_handler.py
@@ -126,17 +126,6 @@ class HuobiJpHandler:
         '''
         return WebAPIErrorCode.OK
 
-    def cancel_expired_order(self):
-        '''
-        期限切れの注文をキャンセルする。
-
-        Returns:
-        --------
-        error_code : WebAPIErrorCode
-            WebAPIエラーコード。
-        '''
-        WebAPIErrorCode.OK
-
     def fetch_balance(self):
         '''
         取引所に預けている残高を取得する。

--- a/src/web_handler/liquid_handler.py
+++ b/src/web_handler/liquid_handler.py
@@ -64,13 +64,68 @@ class LiquidHandler:
         return WebAPIErrorCode.OK, ticker_info
 
     def load_api_key(self):
+        '''
+        API Key, Secret keyをロードする。
+        注文を扱うメソッドを呼ぶ前には本メソッドを実行する必要がある。
+
+        Returns:
+        --------
+        error_code : FileAccessErrorCode
+            ファイルアクセスエラーコード。
+        '''
         return FileAccessErrorCode.OK
 
     def make_buy_market_order(self, crypto_type, volume):
+        '''
+        成行注文（買い）を出す。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨種別。
+        volume : float
+            数量。単位は仮想通貨による。
+        timeout : int
+            注文をキャンセルするまでの時間。[秒]
+            この時間内に約定しなかった場合は cancel_expired_order が呼ばれた時点でキャンセルされる。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        '''
         return WebAPIErrorCode.OK
 
     def make_sell_market_order(self, crypto_type, volume):
+        '''
+        成行注文（売り）を出す。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨種別。
+        volume : float
+            数量。単位は仮想通貨による。
+        timeout : int
+            注文をキャンセルするまでの時間。[秒]
+            この時間内に約定しなかった場合は cancel_expired_order が呼ばれた時点でキャンセルされる。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        '''
         return WebAPIErrorCode.OK
 
     def fetch_balance(self):
+        '''
+        取引所に預けている残高を取得する。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        balance_info : BalanceInfo
+            残高情報。
+        '''
         return WebAPIErrorCode.OK, BalanceInfo()

--- a/src/web_handler/liquid_handler.py
+++ b/src/web_handler/liquid_handler.py
@@ -72,8 +72,5 @@ class LiquidHandler:
     def make_sell_market_order(self, crypto_type, volume):
         return WebAPIErrorCode.OK
 
-    def cancel_expired_order(self):
-        return WebAPIErrorCode.OK
-
     def fetch_balance(self):
         return WebAPIErrorCode.OK, BalanceInfo()

--- a/src/web_handler/zaif_handler.py
+++ b/src/web_handler/zaif_handler.py
@@ -66,13 +66,68 @@ class ZaifHandler:
         return WebAPIErrorCode.OK, ticker_info
 
     def load_api_key(self):
+        '''
+        API Key, Secret keyをロードする。
+        注文を扱うメソッドを呼ぶ前には本メソッドを実行する必要がある。
+
+        Returns:
+        --------
+        error_code : FileAccessErrorCode
+            ファイルアクセスエラーコード。
+        '''
         return FileAccessErrorCode.OK
 
     def make_buy_market_order(self, crypto_type, volume):
+        '''
+        成行注文（買い）を出す。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨種別。
+        volume : float
+            数量。単位は仮想通貨による。
+        timeout : int
+            注文をキャンセルするまでの時間。[秒]
+            この時間内に約定しなかった場合は cancel_expired_order が呼ばれた時点でキャンセルされる。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        '''
         return WebAPIErrorCode.OK
 
     def make_sell_market_order(self, crypto_type, volume):
+        '''
+        成行注文（売り）を出す。
+
+        Parameters:
+        -----------
+        crypto_type : CryptoType
+            仮想通貨種別。
+        volume : float
+            数量。単位は仮想通貨による。
+        timeout : int
+            注文をキャンセルするまでの時間。[秒]
+            この時間内に約定しなかった場合は cancel_expired_order が呼ばれた時点でキャンセルされる。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        '''
         return WebAPIErrorCode.OK
 
     def fetch_balance(self):
-        pass
+        '''
+        取引所に預けている残高を取得する。
+
+        Returns:
+        --------
+        error_code : WebAPIErrorCode
+            WebAPIエラーコード。
+        balance_info : BalanceInfo
+            残高情報。
+        '''
+        return self.impl.fetch_balance()

--- a/src/web_handler/zaif_handler.py
+++ b/src/web_handler/zaif_handler.py
@@ -74,8 +74,5 @@ class ZaifHandler:
     def make_sell_market_order(self, crypto_type, volume):
         return WebAPIErrorCode.OK
 
-    def cancel_expired_order(self):
-        pass
-
     def fetch_balance(self):
         pass


### PR DESCRIPTION
### 概要
2つのリファクタを実施。
* ExchangeHandlerから不要なAPI(CancelExpiredOrder)を削除
  * 成行注文の場合、注文の期限が切れるという事象がほぼ発生しないことが分かったため
* 各web_handlerクラスのAPIコメントを加筆修正